### PR TITLE
consume scancode once to fix #10

### DIFF
--- a/src/arch/x86_64/interrupts/mod.rs
+++ b/src/arch/x86_64/interrupts/mod.rs
@@ -94,6 +94,13 @@ fn idt_init() {
             0xEE,
         );
 
+        idt_set_gate(
+            InterruptIndex::Keyboard.as_u8(),
+            crate::drivers::keyboard::keyboard_interrupt_handler as u64,
+            0x28,
+            0xEE,
+        );
+
         core::arch::asm!(
             "lidt [{}]",
             "sti",

--- a/src/usr/shell.rs
+++ b/src/usr/shell.rs
@@ -103,9 +103,9 @@ impl ModStatusBits {
 static MOD_STATUS: ModStatusBits = ModStatusBits::new();
 
 pub fn init_shell() {
-    crate::drivers::keyboard::init_keyboard(handle_key);
-
     prompt();
+
+		crate::drivers::keyboard::consume_scancode();
 }
 
 pub fn handle_key(mut key: Key) {


### PR DESCRIPTION
This pull request fixes #10. This fixes the issue by consuming a scancode that might've been placed into the 0x60 port during the bootup sequence.